### PR TITLE
Weighted: Reduce bytecode size

### DIFF
--- a/contracts/pools/oracle/PoolPriceOracle.sol
+++ b/contracts/pools/oracle/PoolPriceOracle.sol
@@ -167,7 +167,7 @@ contract PoolPriceOracle {
     /**
      * @dev Tells the sample at a given index in the buffer
      */
-    function _sample(uint256 index) private view returns (bytes32) {
+    function _sample(uint256 index) internal view returns (bytes32) {
         return _samples[index];
     }
 }

--- a/contracts/pools/oracle/Samples.sol
+++ b/contracts/pools/oracle/Samples.sol
@@ -43,7 +43,37 @@ library Samples {
     using WordCodec for uint256;
     using WordCodec for bytes32;
 
+    uint256 internal constant _TIMESTAMP_OFFSET = 0;
+    uint256 internal constant _ACC_LOG_INVARIANT_OFFSET = 31;
+    uint256 internal constant _LOG_INVARIANT_OFFSET = 84;
+    uint256 internal constant _ACC_LOG_BPT_PRICE_OFFSET = 106;
+    uint256 internal constant _LOG_BPT_PRICE_OFFSET = 159;
+    uint256 internal constant _ACC_LOG_PAIR_PRICE_OFFSET = 181;
+    uint256 internal constant _LOG_PAIR_PRICE_OFFSET = 234;
+
     enum Variable { PAIR_PRICE, BPT_PRICE, INVARIANT }
+
+    function instant(bytes32 sample, Variable variable) internal pure returns (int256) {
+        if (variable == Variable.PAIR_PRICE) {
+            return logPairPrice(sample);
+        } else if (variable == Variable.BPT_PRICE) {
+            return logBptPrice(sample);
+        } else {
+            // variable == Variable.INVARIANT
+            return logInvariant(sample);
+        }
+    }
+
+    function accumulator(bytes32 sample, Variable variable) internal pure returns (int256) {
+        if (variable == Variable.PAIR_PRICE) {
+            return accLogPairPrice(sample);
+        } else if (variable == Variable.BPT_PRICE) {
+            return accLogBptPrice(sample);
+        } else {
+            // variable == Variable.INVARIANT
+            return accLogInvariant(sample);
+        }
+    }
 
     /**
      * @dev Updates a sample, accumulating the new reported information based on the elapsed time since the previous
@@ -78,75 +108,53 @@ library Samples {
             );
     }
 
-    function instant(bytes32 sample, Variable variable) internal pure returns (int256) {
-        if (variable == Variable.PAIR_PRICE) {
-            return logPairPrice(sample);
-        } else if (variable == Variable.BPT_PRICE) {
-            return logBptPrice(sample);
-        } else {
-            // variable == Variable.INVARIANT
-            return logInvariant(sample);
-        }
-    }
-
-    function accumulator(bytes32 sample, Variable variable) internal pure returns (int256) {
-        if (variable == Variable.PAIR_PRICE) {
-            return accLogPairPrice(sample);
-        } else if (variable == Variable.BPT_PRICE) {
-            return accLogBptPrice(sample);
-        } else {
-            // variable == Variable.INVARIANT
-            return accLogInvariant(sample);
-        }
-    }
-
     /**
      * @dev Returns the logarithm of a sample's pair price.
      */
     function logPairPrice(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt22(234); // 234 = 53 + 22 + 53 + 22 + 53 + 31
+        return sample.decodeInt22(_LOG_PAIR_PRICE_OFFSET);
     }
 
     /**
      * @dev Returns a sample's time-weighted accumulated pair price logarithm.
      */
     function accLogPairPrice(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt53(181); // 181 = 22 + 53 + 22 + 53 + 31
+        return sample.decodeInt53(_ACC_LOG_PAIR_PRICE_OFFSET);
     }
 
     /**
      * @dev Returns the logarithm of a sample's BPT price.
      */
     function logBptPrice(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt22(159); // 159 = 53 + 22 + 53 + 31
+        return sample.decodeInt22(_LOG_BPT_PRICE_OFFSET);
     }
 
     /**
      * @dev Returns a sample's time-weighted accumulated BPT price logarithm.
      */
     function accLogBptPrice(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt53(106); // 106 = 22 + 53 + 31
+        return sample.decodeInt53(_ACC_LOG_BPT_PRICE_OFFSET);
     }
 
     /**
      * @dev Returns the logarithm of a sample's invariant
      */
     function logInvariant(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt22(84); // 84 = 53 + 31
+        return sample.decodeInt22(_LOG_INVARIANT_OFFSET);
     }
 
     /**
      * @dev Returns a sample's time-weighted accumulated invariant logarithm.
      */
     function accLogInvariant(bytes32 sample) internal pure returns (int256) {
-        return sample.decodeInt53(31);
+        return sample.decodeInt53(_ACC_LOG_INVARIANT_OFFSET);
     }
 
     /**
-     * @dev Tells the timestamp encoded in a sample
+     * @dev Returns the timestamp encoded in a sample
      */
     function timestamp(bytes32 sample) internal pure returns (uint256) {
-        return sample.decodeUint31(0);
+        return sample.decodeUint31(_TIMESTAMP_OFFSET);
     }
 
     /**
@@ -162,12 +170,12 @@ library Samples {
         uint256 _timestamp
     ) internal pure returns (bytes32) {
         return
-            _logPairPrice.encodeInt22(234) |
-            _accLogPairPrice.encodeInt53(181) |
-            _logBptPrice.encodeInt22(159) |
-            _accLogBptPrice.encodeInt53(106) |
-            _logInvariant.encodeInt22(84) |
-            _accLogInvariant.encodeInt53(31) |
-            _timestamp.encodeUint31(0);
+            _logPairPrice.encodeInt22(_LOG_PAIR_PRICE_OFFSET) |
+            _accLogPairPrice.encodeInt53(_ACC_LOG_PAIR_PRICE_OFFSET) |
+            _logBptPrice.encodeInt22(_LOG_BPT_PRICE_OFFSET) |
+            _accLogBptPrice.encodeInt53(_ACC_LOG_BPT_PRICE_OFFSET) |
+            _logInvariant.encodeInt22(_LOG_INVARIANT_OFFSET) |
+            _accLogInvariant.encodeInt53(_ACC_LOG_INVARIANT_OFFSET) |
+            _timestamp.encodeUint31(_TIMESTAMP_OFFSET);
     }
 }

--- a/contracts/pools/weighted/WeightedPool2Tokens.sol
+++ b/contracts/pools/weighted/WeightedPool2Tokens.sol
@@ -35,12 +35,12 @@ contract WeightedPool2Tokens is
     BalancerPoolToken,
     TemporarilyPausable,
     PoolPriceOracle,
-    WeightedPool2TokensMiscData,
     WeightedMath,
     WeightedOracleMath
 {
     using FixedPoint for uint256;
     using WeightedPoolUserDataHelpers for bytes;
+    using WeightedPool2TokensMiscData for bytes32;
 
     uint256 private constant _MINIMUM_BPT = 1e6;
 
@@ -49,6 +49,7 @@ contract WeightedPool2Tokens is
     uint256 private constant _MAX_SWAP_FEE_PERCENTAGE = 1e17; // 10%
     // The swap fee is internally stored using 64 bits, which is enough to represent _MAX_SWAP_FEE_PERCENTAGE.
 
+    bytes32 internal _miscData;
     uint256 private _lastInvariant;
 
     IVault private immutable _vault;
@@ -149,8 +150,25 @@ contract WeightedPool2Tokens is
         return _poolId;
     }
 
-    function getSwapFeePercentage() external view returns (uint256) {
-        return _getMiscData().swapFeePercentage;
+    function getMiscData()
+        external
+        view
+        returns (
+            int256 logInvariant,
+            int256 logTotalSupply,
+            uint256 oracleSampleInitialTimestamp,
+            uint256 oracleIndex,
+            bool oracleEnabled,
+            uint256 swapFeePercentage
+        )
+    {
+        bytes32 miscData = _miscData;
+        logInvariant = miscData.logInvariant();
+        logTotalSupply = miscData.logTotalSupply();
+        oracleSampleInitialTimestamp = miscData.oracleSampleInitialTimestamp();
+        oracleIndex = miscData.oracleIndex();
+        oracleEnabled = miscData.oracleEnabled();
+        swapFeePercentage = miscData.swapFeePercentage();
     }
 
     // Caller must be approved by the Vault's Authorizer
@@ -162,10 +180,12 @@ contract WeightedPool2Tokens is
         _require(swapFeePercentage >= _MIN_SWAP_FEE_PERCENTAGE, Errors.MIN_SWAP_FEE_PERCENTAGE);
         _require(swapFeePercentage <= _MAX_SWAP_FEE_PERCENTAGE, Errors.MAX_SWAP_FEE_PERCENTAGE);
 
-        MiscData memory miscData = _getMiscData();
-        miscData.swapFeePercentage = swapFeePercentage;
-        _setMiscData(miscData);
+        _miscData = _miscData.setSwapFeePercentage(swapFeePercentage);
         emit SwapFeePercentageChanged(swapFeePercentage);
+    }
+
+    function _getSwapFeePercentage() internal view returns (uint256) {
+        return _miscData.swapFeePercentage();
     }
 
     function enableOracle() external whenNotPaused authenticate {
@@ -173,19 +193,13 @@ contract WeightedPool2Tokens is
 
         // Cache log invariant and supply only if the pool was initialized
         if (totalSupply() > 0) {
-            _cacheInvariantAndSupply(_getMiscData());
+            _cacheInvariantAndSupply();
         }
     }
 
-    function _setOracleEnabled(bool enabled) private {
-        MiscData memory miscData = _getMiscData();
-        miscData.oracleEnabled = enabled;
-        _setMiscData(miscData);
+    function _setOracleEnabled(bool enabled) internal {
+        _miscData = _miscData.setOracleEnabled(enabled);
         emit OracleEnabledChanged(enabled);
-    }
-
-    function isOracleEnabled() external view returns (bool) {
-        return _getMiscData().oracleEnabled;
     }
 
     // Caller must be approved by the Vault's Authorizer
@@ -243,10 +257,8 @@ contract WeightedPool2Tokens is
         balanceTokenOut = _upscale(balanceTokenOut, scalingFactorTokenOut);
 
         // Update price oracle with the pre-swap balances
-        MiscData memory miscData = _getMiscData();
         bool tokenInIsToken0 = request.tokenIn == _token0;
         _updateOracle(
-            miscData,
             request.lastChangeBlock,
             tokenInIsToken0 ? balanceTokenIn : balanceTokenOut,
             tokenInIsToken0 ? balanceTokenOut : balanceTokenIn
@@ -255,7 +267,7 @@ contract WeightedPool2Tokens is
         if (request.kind == IVault.SwapKind.GIVEN_IN) {
             // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
             // This is amount - fee amount, so we round up (favoring a higher fee amount).
-            uint256 feeAmount = request.amount.mulUp(miscData.swapFeePercentage);
+            uint256 feeAmount = request.amount.mulUp(_getSwapFeePercentage());
             request.amount = _upscale(request.amount.sub(feeAmount), scalingFactorTokenIn);
 
             uint256 amountOut = _onSwapGivenIn(request, balanceTokenIn, balanceTokenOut);
@@ -272,7 +284,7 @@ contract WeightedPool2Tokens is
 
             // Fees are added after scaling happens, to reduce the complexity of the rounding direction analysis.
             // This is amount + fee amount, so we round up (favoring a higher fee amount).
-            return amountIn.divUp(miscData.swapFeePercentage.complement());
+            return amountIn.divUp(_getSwapFeePercentage().complement());
         }
     }
 
@@ -331,7 +343,6 @@ contract WeightedPool2Tokens is
         // All joins, including initializations, are disabled while the contract is paused.
 
         uint256[] memory scalingFactors = _scalingFactors();
-        MiscData memory miscData = _getMiscData();
 
         uint256 bptAmountOut;
         if (totalSupply() == 0) {
@@ -353,7 +364,7 @@ contract WeightedPool2Tokens is
             _upscaleArray(balances, scalingFactors);
 
             // Update price oracle with the pre-join balances
-            _updateOracle(miscData, lastChangeBlock, balances[0], balances[1]);
+            _updateOracle(lastChangeBlock, balances[0], balances[1]);
 
             (bptAmountOut, amountsIn, dueProtocolFeeAmounts) = _onJoinPool(
                 poolId,
@@ -362,8 +373,7 @@ contract WeightedPool2Tokens is
                 balances,
                 lastChangeBlock,
                 protocolSwapFeePercentage,
-                userData,
-                miscData
+                userData
             );
 
             // Note we no longer use `balances` after calling `_onJoinPool`, which may mutate it.
@@ -378,7 +388,7 @@ contract WeightedPool2Tokens is
 
         // Update cached total supply and invariant using the results after the join that will be used for future
         // oracle updates.
-        _cacheInvariantAndSupply(miscData);
+        _cacheInvariantAndSupply();
     }
 
     /**
@@ -444,8 +454,7 @@ contract WeightedPool2Tokens is
         uint256[] memory balances,
         uint256,
         uint256 protocolSwapFeePercentage,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     )
         private
         returns (
@@ -471,7 +480,7 @@ contract WeightedPool2Tokens is
 
         // Update current balances by subtracting the protocol fee amounts
         _mutateAmounts(balances, dueProtocolFeeAmounts, FixedPoint.sub);
-        (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(balances, normalizedWeights, userData, miscData);
+        (uint256 bptAmountOut, uint256[] memory amountsIn) = _doJoin(balances, normalizedWeights, userData);
 
         // Update the invariant with the balances the Pool will have after the join, in order to compute the
         // protocol swap fee amounts due in future joins and exits.
@@ -483,15 +492,14 @@ contract WeightedPool2Tokens is
     function _doJoin(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
         WeightedPool.JoinKind kind = userData.joinKind();
 
         if (kind == WeightedPool.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
-            return _joinExactTokensInForBPTOut(balances, normalizedWeights, userData, miscData);
+            return _joinExactTokensInForBPTOut(balances, normalizedWeights, userData);
         } else if (kind == WeightedPool.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
-            return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData, miscData);
+            return _joinTokenInForExactBPTOut(balances, normalizedWeights, userData);
         } else {
             _revert(Errors.UNHANDLED_JOIN_KIND);
         }
@@ -500,8 +508,7 @@ contract WeightedPool2Tokens is
     function _joinExactTokensInForBPTOut(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
         (uint256[] memory amountsIn, uint256 minBPTAmountOut) = userData.exactTokensInForBptOut();
         InputHelpers.ensureInputLengthMatch(amountsIn.length, 2);
@@ -513,7 +520,7 @@ contract WeightedPool2Tokens is
             normalizedWeights,
             amountsIn,
             totalSupply(),
-            miscData.swapFeePercentage
+            _getSwapFeePercentage()
         );
 
         _require(bptAmountOut >= minBPTAmountOut, Errors.BPT_OUT_MIN_AMOUNT);
@@ -524,8 +531,7 @@ contract WeightedPool2Tokens is
     function _joinTokenInForExactBPTOut(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
         (uint256 bptAmountOut, uint256 tokenIndex) = userData.tokenInForExactBptOut();
         // Note that there is no maximum amountIn parameter: this is handled by `IVault.joinPool`.
@@ -538,7 +544,7 @@ contract WeightedPool2Tokens is
             normalizedWeights[tokenIndex],
             bptAmountOut,
             totalSupply(),
-            miscData.swapFeePercentage
+            _getSwapFeePercentage()
         );
 
         return (bptAmountOut, amountsIn);
@@ -558,7 +564,6 @@ contract WeightedPool2Tokens is
         uint256[] memory scalingFactors = _scalingFactors();
         _upscaleArray(balances, scalingFactors);
 
-        MiscData memory miscData = _getMiscData();
         (uint256 bptAmountIn, uint256[] memory amountsOut, uint256[] memory dueProtocolFeeAmounts) = _onExitPool(
             poolId,
             sender,
@@ -566,8 +571,7 @@ contract WeightedPool2Tokens is
             balances,
             lastChangeBlock,
             protocolSwapFeePercentage,
-            userData,
-            miscData
+            userData
         );
 
         // Note we no longer use `balances` after calling `_onExitPool`, which may mutate it.
@@ -581,7 +585,7 @@ contract WeightedPool2Tokens is
         // Update cached total supply and invariant using the results after the exit that will be used for future
         // oracle updates, only if the pool was not paused (to minimize code paths taken while paused).
         if (_isNotPaused()) {
-            _cacheInvariantAndSupply(miscData);
+            _cacheInvariantAndSupply();
         }
 
         return (amountsOut, dueProtocolFeeAmounts);
@@ -611,8 +615,7 @@ contract WeightedPool2Tokens is
         uint256[] memory balances,
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     )
         private
         returns (
@@ -628,7 +631,7 @@ contract WeightedPool2Tokens is
 
         if (_isNotPaused()) {
             // Update price oracle with the pre-exit balances
-            _updateOracle(miscData, lastChangeBlock, balances[0], balances[1]);
+            _updateOracle(lastChangeBlock, balances[0], balances[1]);
 
             // Due protocol swap fee amounts are computed by measuring the growth of the invariant between the previous
             // join or exit event and now - the invariant's growth is due exclusively to swap fees. This avoids
@@ -650,7 +653,7 @@ contract WeightedPool2Tokens is
             dueProtocolFeeAmounts = new uint256[](2);
         }
 
-        (bptAmountIn, amountsOut) = _doExit(balances, normalizedWeights, userData, miscData);
+        (bptAmountIn, amountsOut) = _doExit(balances, normalizedWeights, userData);
 
         // Update the invariant with the balances the Pool will have after the exit, in order to compute the
         // protocol swap fees due in future joins and exits.
@@ -662,26 +665,24 @@ contract WeightedPool2Tokens is
     function _doExit(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view returns (uint256, uint256[] memory) {
         WeightedPool.ExitKind kind = userData.exitKind();
 
         if (kind == WeightedPool.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
-            return _exitExactBPTInForTokenOut(balances, normalizedWeights, userData, miscData);
+            return _exitExactBPTInForTokenOut(balances, normalizedWeights, userData);
         } else if (kind == WeightedPool.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
             return _exitExactBPTInForTokensOut(balances, userData);
         } else {
             // ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-            return _exitBPTInForExactTokensOut(balances, normalizedWeights, userData, miscData);
+            return _exitBPTInForExactTokensOut(balances, normalizedWeights, userData);
         }
     }
 
     function _exitExactBPTInForTokenOut(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view whenNotPaused returns (uint256, uint256[] memory) {
         // This exit function is disabled if the contract is paused.
 
@@ -699,7 +700,7 @@ contract WeightedPool2Tokens is
             normalizedWeights[tokenIndex],
             bptAmountIn,
             totalSupply(),
-            miscData.swapFeePercentage
+            _getSwapFeePercentage()
         );
 
         return (bptAmountIn, amountsOut);
@@ -725,8 +726,7 @@ contract WeightedPool2Tokens is
     function _exitBPTInForExactTokensOut(
         uint256[] memory balances,
         uint256[] memory normalizedWeights,
-        bytes memory userData,
-        MiscData memory miscData
+        bytes memory userData
     ) private view whenNotPaused returns (uint256, uint256[] memory) {
         // This exit function is disabled if the contract is paused.
 
@@ -739,7 +739,7 @@ contract WeightedPool2Tokens is
             normalizedWeights,
             amountsOut,
             totalSupply(),
-            miscData.swapFeePercentage
+            _getSwapFeePercentage()
         );
         _require(bptAmountIn <= maxBPTAmountIn, Errors.BPT_IN_MAX_AMOUNT);
 
@@ -760,7 +760,7 @@ contract WeightedPool2Tokens is
     {
         results = new int256[](queries.length);
 
-        uint256 oracleIndex = _getMiscData().oracleIndex;
+        uint256 oracleIndex = _miscData.oracleIndex();
 
         OracleAccumulatorQuery memory query;
         for (uint256 i = 0; i < queries.length; ++i) {
@@ -782,7 +782,7 @@ contract WeightedPool2Tokens is
     {
         results = new uint256[](queries.length);
 
-        uint256 oracleIndex = _getMiscData().oracleIndex;
+        uint256 oracleIndex = _miscData.oracleIndex();
 
         OracleAverageQuery memory query;
         for (uint256 i = 0; i < queries.length; ++i) {
@@ -801,12 +801,12 @@ contract WeightedPool2Tokens is
      * `lastChangeBlock` as the number of the block in which any of the balances last changed.
      */
     function _updateOracle(
-        MiscData memory miscData,
         uint256 lastChangeBlock,
         uint256 balanceToken0,
         uint256 balanceToken1
     ) internal {
-        if (miscData.oracleEnabled && block.number > lastChangeBlock) {
+        bytes32 miscData = _miscData;
+        if (miscData.oracleEnabled() && block.number > lastChangeBlock) {
             int256 logSpotPrice = WeightedOracleMath._calcLogSpotPrice(
                 _normalizedWeight0,
                 balanceToken0,
@@ -817,24 +817,24 @@ contract WeightedPool2Tokens is
             int256 logBPTPrice = WeightedOracleMath._calcLogBPTPrice(
                 _normalizedWeight0,
                 balanceToken0,
-                miscData.logTotalSupply
+                miscData.logTotalSupply()
             );
 
-            uint256 oracleCurrentIndex = miscData.oracleIndex;
-            uint256 oracleCurrentSampleInitialTimestamp = miscData.oracleSampleInitialTimestamp;
+            uint256 oracleCurrentIndex = miscData.oracleIndex();
+            uint256 oracleCurrentSampleInitialTimestamp = miscData.oracleSampleInitialTimestamp();
             uint256 oracleUpdatedIndex = _processPriceData(
                 oracleCurrentSampleInitialTimestamp,
                 oracleCurrentIndex,
                 logSpotPrice,
                 logBPTPrice,
-                miscData.logInvariant
+                miscData.logInvariant()
             );
 
             if (oracleCurrentIndex != oracleUpdatedIndex) {
                 // solhint-disable not-rely-on-time
-                miscData.oracleIndex = oracleUpdatedIndex;
-                miscData.oracleSampleInitialTimestamp = block.timestamp;
-                _setMiscData(miscData);
+                miscData = miscData.setOracleIndex(oracleUpdatedIndex);
+                miscData = miscData.setOracleSampleInitialTimestamp(block.timestamp);
+                _miscData = miscData;
             }
         }
     }
@@ -848,11 +848,12 @@ contract WeightedPool2Tokens is
      * also alter the invariant due to collected swap fees, but this growth is considered negligible and not accounted
      * for.
      */
-    function _cacheInvariantAndSupply(MiscData memory miscData) internal {
-        if (miscData.oracleEnabled) {
-            miscData.logInvariant = WeightedOracleMath._toLowResLog(_lastInvariant);
-            miscData.logTotalSupply = WeightedOracleMath._toLowResLog(totalSupply());
-            _setMiscData(miscData);
+    function _cacheInvariantAndSupply() internal {
+        bytes32 miscData = _miscData;
+        if (miscData.oracleEnabled()) {
+            miscData.setLogInvariant(WeightedOracleMath._toLowResLog(_lastInvariant));
+            miscData.setLogTotalSupply(WeightedOracleMath._toLowResLog(totalSupply()));
+            _miscData = miscData;
         }
     }
 
@@ -887,7 +888,6 @@ contract WeightedPool2Tokens is
             lastChangeBlock,
             protocolSwapFeePercentage,
             userData,
-            _getMiscData(),
             _onJoinPool,
             _downscaleUpArray
         );
@@ -926,7 +926,6 @@ contract WeightedPool2Tokens is
             lastChangeBlock,
             protocolSwapFeePercentage,
             userData,
-            _getMiscData(),
             _onExitPool,
             _downscaleDownArray
         );
@@ -1114,8 +1113,7 @@ contract WeightedPool2Tokens is
         uint256 lastChangeBlock,
         uint256 protocolSwapFeePercentage,
         bytes memory userData,
-        MiscData memory miscData,
-        function(bytes32, address, address, uint256[] memory, uint256, uint256, bytes memory, MiscData memory)
+        function(bytes32, address, address, uint256[] memory, uint256, uint256, bytes memory)
             internal
             returns (uint256, uint256[] memory, uint256[] memory) _action,
         function(uint256[] memory, uint256[] memory) internal view _downscaleArray
@@ -1198,8 +1196,7 @@ contract WeightedPool2Tokens is
                 balances,
                 lastChangeBlock,
                 protocolSwapFeePercentage,
-                userData,
-                miscData
+                userData
             );
 
             _downscaleArray(tokenAmounts, scalingFactors);

--- a/contracts/pools/weighted/WeightedPool2Tokens.sol
+++ b/contracts/pools/weighted/WeightedPool2Tokens.sol
@@ -851,8 +851,8 @@ contract WeightedPool2Tokens is
     function _cacheInvariantAndSupply() internal {
         bytes32 miscData = _miscData;
         if (miscData.oracleEnabled()) {
-            miscData.setLogInvariant(WeightedOracleMath._toLowResLog(_lastInvariant));
-            miscData.setLogTotalSupply(WeightedOracleMath._toLowResLog(totalSupply()));
+            miscData = miscData.setLogInvariant(WeightedOracleMath._toLowResLog(_lastInvariant));
+            miscData = miscData.setLogTotalSupply(WeightedOracleMath._toLowResLog(totalSupply()));
             _miscData = miscData;
         }
     }

--- a/contracts/pools/weighted/WeightedPool2TokensMiscData.sol
+++ b/contracts/pools/weighted/WeightedPool2TokensMiscData.sol
@@ -32,54 +32,98 @@ import "../../lib/helpers/WordCodec.sol";
  *
  * Note that are not using the most-significant 106 bits.
  */
-contract WeightedPool2TokensMiscData {
+library WeightedPool2TokensMiscData {
     using WordCodec for bytes32;
     using WordCodec for uint256;
 
-    uint256 internal constant _MISC_LOG_INVARIANT_OFFSET = 0;
-    uint256 internal constant _MISC_LOG_TOTAL_SUPPLY_OFFSET = 22;
-    uint256 internal constant _MISC_ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET = 44;
-    uint256 internal constant _MISC_ORACLE_INDEX_OFFSET = 75;
-    uint256 internal constant _MISC_ORACLE_ENABLED_OFFSET = 85;
-    uint256 internal constant _MISC_SWAP_FEE_PERCENTAGE_OFFSET = 86;
+    uint256 internal constant _LOG_INVARIANT_OFFSET = 0;
+    uint256 internal constant _LOG_TOTAL_SUPPLY_OFFSET = 22;
+    uint256 internal constant _ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET = 44;
+    uint256 internal constant _ORACLE_INDEX_OFFSET = 75;
+    uint256 internal constant _ORACLE_ENABLED_OFFSET = 85;
+    uint256 internal constant _SWAP_FEE_PERCENTAGE_OFFSET = 86;
 
-    struct MiscData {
-        uint256 swapFeePercentage;
-        bool oracleEnabled;
-        uint256 oracleIndex;
-        uint256 oracleSampleInitialTimestamp;
-        int256 logTotalSupply;
-        int256 logInvariant;
+    /**
+     * @dev Returns the logarithm of the invariant
+     */
+    function logInvariant(bytes32 data) internal pure returns (int256) {
+        return data.decodeInt22(_LOG_INVARIANT_OFFSET);
     }
 
-    bytes32 private _miscData;
-
-    function getMiscData() external view returns (MiscData memory) {
-        return _getMiscData();
+    /**
+     * @dev Returns the logarithm of the total supply
+     */
+    function logTotalSupply(bytes32 data) internal pure returns (int256) {
+        return data.decodeInt22(_LOG_TOTAL_SUPPLY_OFFSET);
     }
 
-    function _getMiscData() internal view returns (MiscData memory) {
-        bytes32 miscData = _miscData;
-
-        return
-            MiscData({
-                swapFeePercentage: miscData.decodeUint64(_MISC_SWAP_FEE_PERCENTAGE_OFFSET),
-                oracleEnabled: miscData.decodeBool(_MISC_ORACLE_ENABLED_OFFSET),
-                oracleIndex: miscData.decodeUint10(_MISC_ORACLE_INDEX_OFFSET),
-                oracleSampleInitialTimestamp: miscData.decodeUint31(_MISC_ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET),
-                logTotalSupply: miscData.decodeInt22(_MISC_LOG_TOTAL_SUPPLY_OFFSET),
-                logInvariant: miscData.decodeInt22(_MISC_LOG_INVARIANT_OFFSET)
-            });
+    /**
+     * @dev Returns the initial timestamp of the oracle's current sample
+     */
+    function oracleSampleInitialTimestamp(bytes32 data) internal pure returns (uint256) {
+        return data.decodeUint31(_ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET);
     }
 
-    function _setMiscData(MiscData memory _data) internal {
-        bytes32 data = bytes32(0);
-        data = data.storeUint64(_data.swapFeePercentage, _MISC_SWAP_FEE_PERCENTAGE_OFFSET);
-        data = data.storeBoolean(_data.oracleEnabled, _MISC_ORACLE_ENABLED_OFFSET);
-        data = data.storeUint10(_data.oracleIndex, _MISC_ORACLE_INDEX_OFFSET);
-        data = data.storeUint31(_data.oracleSampleInitialTimestamp, _MISC_ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET);
-        data = data.storeInt22(_data.logTotalSupply, _MISC_LOG_TOTAL_SUPPLY_OFFSET);
-        data = data.storeInt22(_data.logInvariant, _MISC_LOG_INVARIANT_OFFSET);
-        _miscData = data;
+    /**
+     * @dev Returns the index of the oracle's current sample
+     */
+    function oracleIndex(bytes32 data) internal pure returns (uint256) {
+        return data.decodeUint10(_ORACLE_INDEX_OFFSET);
+    }
+
+    /**
+     * @dev Returns the oracle enable config
+     */
+    function oracleEnabled(bytes32 data) internal pure returns (bool) {
+        return data.decodeBool(_ORACLE_ENABLED_OFFSET);
+    }
+
+    /**
+     * @dev Returns swap fee percentage
+     */
+    function swapFeePercentage(bytes32 data) internal pure returns (uint256) {
+        return data.decodeUint64(_SWAP_FEE_PERCENTAGE_OFFSET);
+    }
+
+    /**
+     * @dev Sets the logarithm of the invariant in a given bytes32 word
+     */
+    function setLogInvariant(bytes32 data, int256 _logInvariant) internal pure returns (bytes32) {
+        return data.storeInt22(_logInvariant, _LOG_INVARIANT_OFFSET);
+    }
+
+    /**
+     * @dev Sets the logarithm of the total supply in a given bytes32 word
+     */
+    function setLogTotalSupply(bytes32 data, int256 _logTotalSupply) internal pure returns (bytes32) {
+        return data.storeInt22(_logTotalSupply, _LOG_TOTAL_SUPPLY_OFFSET);
+    }
+
+    /**
+     * @dev Sets the initial timestamp of the oracle's current sample in a given bytes32 word
+     */
+    function setOracleSampleInitialTimestamp(bytes32 data, uint256 _initialTimestamp) internal pure returns (bytes32) {
+        return data.storeUint31(_initialTimestamp, _ORACLE_SAMPLE_INITIAL_TIMESTAMP_OFFSET);
+    }
+
+    /**
+     * @dev Sets the index of the oracle's current sample in a given bytes32 word
+     */
+    function setOracleIndex(bytes32 data, uint256 _oracleIndex) internal pure returns (bytes32) {
+        return data.storeUint10(_oracleIndex, _ORACLE_INDEX_OFFSET);
+    }
+
+    /**
+     * @dev Sets the oracle enable config a given bytes32 word
+     */
+    function setOracleEnabled(bytes32 data, bool _oracleEnabled) internal pure returns (bytes32) {
+        return data.storeBoolean(_oracleEnabled, _ORACLE_ENABLED_OFFSET);
+    }
+
+    /**
+     * @dev Sets the swap fee percentage in a given bytes32 word
+     */
+    function setSwapFeePercentage(bytes32 data, uint256 _swapFeePercentage) internal pure returns (bytes32) {
+        return data.storeUint64(_swapFeePercentage, _SWAP_FEE_PERCENTAGE_OFFSET);
     }
 }

--- a/contracts/test/PoolPriceOracleMock.sol
+++ b/contracts/test/PoolPriceOracleMock.sol
@@ -33,31 +33,7 @@ contract PoolPriceOracleMock is PoolPriceOracle {
 
     event PriceDataProcessed(bool newSample, uint256 sampleIndex);
 
-    function mockSample(uint256 index, Sample memory sample) public {
-        _samples[index] = pack(sample);
-    }
-
-    function mockSamples(uint256[] memory indexes, Sample[] memory samples) public {
-        for (uint256 i = 0; i < indexes.length; i++) {
-            _samples[indexes[i]] = pack(samples[i]);
-        }
-    }
-
-    function getSample(uint256 index) public view returns (Sample memory) {
-        return unpack(_samples[index]);
-    }
-
-    function update(
-        bytes32 sample,
-        int256 logPairPrice,
-        int256 logBptPrice,
-        int256 logInvariant,
-        uint256 timestamp
-    ) public pure returns (Sample memory) {
-        return unpack(sample.update(logPairPrice, logBptPrice, logInvariant, timestamp));
-    }
-
-    function pack(Sample memory sample) public pure returns (bytes32) {
+    function encode(Sample memory sample) public pure returns (bytes32) {
         return
             Samples.pack(
                 sample.logPairPrice,
@@ -70,7 +46,7 @@ contract PoolPriceOracleMock is PoolPriceOracle {
             );
     }
 
-    function unpack(bytes32 sample) public pure returns (Sample memory) {
+    function decode(bytes32 sample) public pure returns (Sample memory) {
         return
             Sample({
                 logPairPrice: sample.logPairPrice(),
@@ -81,6 +57,30 @@ contract PoolPriceOracleMock is PoolPriceOracle {
                 accLogInvariant: sample.accLogInvariant(),
                 timestamp: sample.timestamp()
             });
+    }
+
+    function mockSample(uint256 index, Sample memory sample) public {
+        _samples[index] = encode(sample);
+    }
+
+    function mockSamples(uint256[] memory indexes, Sample[] memory samples) public {
+        for (uint256 i = 0; i < indexes.length; i++) {
+            _samples[indexes[i]] = encode(samples[i]);
+        }
+    }
+
+    function getSample(uint256 index) public view returns (Sample memory) {
+        return decode(_samples[index]);
+    }
+
+    function update(
+        bytes32 sample,
+        int256 logPairPrice,
+        int256 logBptPrice,
+        int256 logInvariant,
+        uint256 timestamp
+    ) public pure returns (Sample memory) {
+        return decode(sample.update(logPairPrice, logBptPrice, logInvariant, timestamp));
     }
 
     function processPriceData(

--- a/contracts/test/WeightedPool2TokensMock.sol
+++ b/contracts/test/WeightedPool2TokensMock.sol
@@ -20,15 +20,36 @@ import "./MockWeightedOracleMath.sol";
 import "../pools/weighted/WeightedPool2Tokens.sol";
 
 contract WeightedPool2TokensMock is WeightedPool2Tokens, PoolPriceOracleMock, MockWeightedOracleMath {
-    constructor(NewPoolParams memory params) WeightedPool2Tokens(params) {}
+    using WeightedPool2TokensMiscData for bytes32;
 
-    function setMiscData(MiscData memory data) external {
-        return _setMiscData(data);
+    struct MiscData {
+        int256 logInvariant;
+        int256 logTotalSupply;
+        uint256 oracleSampleInitialTimestamp;
+        uint256 oracleIndex;
+        bool oracleEnabled;
+        uint256 swapFeePercentage;
     }
 
+    constructor(NewPoolParams memory params) WeightedPool2Tokens(params) {}
+
     function mockOracleDisabled() external {
-        MiscData memory data = _getMiscData();
-        data.oracleEnabled = false;
-        _setMiscData(data);
+        _setOracleEnabled(false);
+    }
+
+    function mockMiscData(MiscData memory miscData) external {
+        _miscData = encode(miscData);
+    }
+
+    /**
+     * @dev Encodes a misc data object into a bytes32
+     */
+    function encode(MiscData memory _data) private pure returns (bytes32 data) {
+        data = data.setSwapFeePercentage(_data.swapFeePercentage);
+        data = data.setOracleEnabled(_data.oracleEnabled);
+        data = data.setOracleIndex(_data.oracleIndex);
+        data = data.setOracleSampleInitialTimestamp(_data.oracleSampleInitialTimestamp);
+        data = data.setLogTotalSupply(_data.logTotalSupply);
+        data = data.setLogInvariant(_data.logInvariant);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -39,8 +39,7 @@ export default {
   networks: {
     hardhat: {
       chainId: CHAIN_IDS.hardhat,
-      saveDeployments: true,
-      allowUnlimitedContractSize: true,
+      saveDeployments: true
     },
     dockerParity: {
       gas: 10000000,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -39,7 +39,7 @@ export default {
   networks: {
     hardhat: {
       chainId: CHAIN_IDS.hardhat,
-      saveDeployments: true
+      saveDeployments: true,
     },
     dockerParity: {
       gas: 10000000,

--- a/test/helpers/models/pools/weighted/WeightedPool.ts
+++ b/test/helpers/models/pools/weighted/WeightedPool.ts
@@ -147,11 +147,19 @@ export default class WeightedPool {
   }
 
   async isOracleEnabled(): Promise<boolean> {
-    return this.instance.isOracleEnabled();
+    return (await this.getMiscData()).oracleEnabled;
   }
 
   async getMiscData(): Promise<MiscData> {
-    return this.instance.getMiscData();
+    const result = await this.instance.getMiscData();
+    return {
+      logInvariant: result[0],
+      logTotalSupply: result[1],
+      oracleSampleInitialTimestamp: result[2],
+      oracleIndex: result[3],
+      oracleEnabled: result[4],
+      swapFeePercentage: result[5],
+    };
   }
 
   async getSample(oracleIndex?: BigNumberish): Promise<Sample> {
@@ -160,7 +168,7 @@ export default class WeightedPool {
   }
 
   async getSwapFeePercentage(): Promise<BigNumber> {
-    return this.instance.getSwapFeePercentage();
+    return (await this.getMiscData()).swapFeePercentage;
   }
 
   async getNormalizedWeights(): Promise<BigNumber[]> {

--- a/test/helpers/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/test/helpers/models/pools/weighted/WeightedPoolDeployer.ts
@@ -19,9 +19,9 @@ export default {
     const vault = await VaultDeployer.deploy(TypesConverter.toRawVaultDeployment(params));
     const pool = await (params.fromFactory ? this._deployFromFactory : this._deployStandalone)(deployment, vault);
 
-    const { tokens, weights, swapFeePercentage } = deployment;
+    const { tokens, weights, swapFeePercentage, twoTokens } = deployment;
     const poolId = await pool.getPoolId();
-    return new WeightedPool(pool, poolId, vault, tokens, weights, swapFeePercentage);
+    return new WeightedPool(pool, poolId, vault, tokens, weights, swapFeePercentage, twoTokens);
   },
 
   async _deployStandalone(params: WeightedPoolDeployment, vault: Vault): Promise<Contract> {

--- a/test/pools/PoolPriceOracle.test.ts
+++ b/test/pools/PoolPriceOracle.test.ts
@@ -26,7 +26,7 @@ describe('PoolPriceOracle', () => {
       accLogInvariant: BigNumberish,
       timestamp: BigNumberish
     ) => {
-      const packedSample = await oracle.pack({
+      const packedSample = await oracle.encode({
         logPairPrice,
         accLogPairPrice,
         logBptPrice,
@@ -36,7 +36,7 @@ describe('PoolPriceOracle', () => {
         timestamp,
       });
 
-      const sample = await oracle.unpack(packedSample);
+      const sample = await oracle.decode(packedSample);
       expect(sample.logPairPrice).to.be.equal(logPairPrice);
       expect(sample.accLogPairPrice).to.be.equal(accLogPairPrice);
       expect(sample.logBptPrice).to.be.equal(logBptPrice);
@@ -92,7 +92,7 @@ describe('PoolPriceOracle', () => {
       logInv: BigNumberish,
       elapsed: BigNumberish
     ) => {
-      const prevSample = await oracle.unpack(sample);
+      const prevSample = await oracle.decode(sample);
       const timestamp = prevSample.timestamp.add(elapsed);
 
       const newSample = await oracle.update(sample, logPairPrice, logBptPrice, logInv, timestamp);
@@ -107,7 +107,7 @@ describe('PoolPriceOracle', () => {
     };
 
     it('updates the sample correctly', async () => {
-      const sample = await oracle.pack({
+      const sample = await oracle.encode({
         logPairPrice: 1,
         accLogPairPrice: 10,
         logBptPrice: 2,

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -344,7 +344,7 @@ describe('WeightedPool', function () {
         });
       });
 
-      describe('oracle setting', () => {
+      describe.only('oracle setting', () => {
         const action = () => pool.enableOracle({ from: admin });
 
         sharedBeforeEach('grant role to admin', async () => {

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -406,7 +406,7 @@ describe('WeightedPool', function () {
         logInvariant: BigNumberish,
         logTotalSupply: BigNumberish
       ) => {
-        await pool.instance.setMiscData({
+        await pool.instance.mockMiscData({
           swapFeePercentage,
           oracleEnabled,
           oracleIndex,

--- a/test/pools/weighted/WeightedPool.test.ts
+++ b/test/pools/weighted/WeightedPool.test.ts
@@ -344,7 +344,7 @@ describe('WeightedPool', function () {
         });
       });
 
-      describe.only('oracle setting', () => {
+      describe('oracle setting', () => {
         const action = () => pool.enableOracle({ from: admin });
 
         sharedBeforeEach('grant role to admin', async () => {


### PR DESCRIPTION
It reduces the bytecode of the weighted pool factory for 2 tokens from `24.726` to `23.942`
It also reduces the gas costs of swaps, e.g. for one pool it's being reduced from `133.1k` and `110.2k` to `132.5k` and `110.0k`, for buffer updates and re-use respectively