### PR TITLE
Added Distributor package for distributing rewards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,28 @@ jobs:
       - name: Test
         run: yarn workspaces foreach --verbose --include @balancer-labs/v2-asset-manager-* run test
 
+  test-distributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: "**/node_modules"
+          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn --immutable
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Compile
+        run: yarn build
+      - name: Test
+        run: yarn workspace @balancer-labs/v2-distributors test
+
   benchmark:
     runs-on: ubuntu-latest
     steps:

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -1,4 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma experimental ABIEncoderV2;
 

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -14,6 +14,7 @@
 
 pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/MerkleProof.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
@@ -27,6 +28,7 @@ import "./interfaces/IDistributor.sol";
 pragma solidity ^0.7.0;
 
 contract MerkleRedeem is IDistributor, Ownable {
+    using FixedPoint for uint256;
     using SafeERC20 for IERC20;
 
     IERC20 public rewardToken;
@@ -46,7 +48,7 @@ contract MerkleRedeem is IDistributor, Ownable {
     function _disburse(address _recipient, uint256 _balance) private {
         if (_balance > 0) {
             emit RewardPaid(_recipient, address(rewardToken), _balance);
-            require(rewardToken.transfer(_recipient, _balance), "ERR_TRANSFER_FAILED");
+            rewardToken.safeTransfer(_recipient, _balance);
         }
     }
 
@@ -115,7 +117,7 @@ contract MerkleRedeem is IDistributor, Ownable {
                 "Incorrect merkle proof"
             );
 
-            totalBalance += claim.balance;
+            totalBalance = totalBalance.add(claim.balance);
             claimed[claim.week][_liquidityProvider] = true;
         }
 

--- a/pkg/distributors/contracts/MerkleRedeem.sol
+++ b/pkg/distributors/contracts/MerkleRedeem.sol
@@ -1,0 +1,151 @@
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/MerkleProof.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
+
+pragma solidity ^0.7.0;
+
+contract MerkleRedeem is Ownable {
+    IERC20 public rewardToken;
+
+    event Claimed(address _claimant, uint256 _balance);
+
+    // Recorded weeks
+    mapping(uint256 => bytes32) public weekMerkleRoots;
+    mapping(uint256 => mapping(address => bool)) public claimed;
+
+    IVault public vault;
+
+    constructor(address _vault, address _rewardToken) {
+        vault = IVault(_vault);
+        rewardToken = IERC20(_rewardToken);
+        rewardToken.approve(address(vault), type(uint256).max);
+    }
+
+    function _disburse(address _recipient, uint256 _balance) private {
+        if (_balance > 0) {
+            emit Claimed(_recipient, _balance);
+            require(rewardToken.transfer(_recipient, _balance), "ERR_TRANSFER_FAILED");
+        }
+    }
+
+    function _disburseToInternalBalance(address payable _recipient, uint256 _balance) private {
+        if (_balance > 0) {
+            IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](1);
+
+            ops[0] = IVault.UserBalanceOp({
+                asset: IAsset(address(rewardToken)),
+                amount: _balance,
+                sender: address(this),
+                recipient: _recipient,
+                kind: IVault.UserBalanceOpKind.DEPOSIT_INTERNAL
+            });
+
+            vault.manageUserBalance(ops);
+
+            emit Claimed(_recipient, _balance);
+        }
+    }
+
+    /**
+     * @notice Allows a user to claim a particular weeks worth of rewards
+     */
+    function claimWeek(
+        address payable _liquidityProvider,
+        uint256 _week,
+        uint256 _claimedBalance,
+        bytes32[] memory _merkleProof,
+        bool internalBalance
+    ) public {
+        require(msg.sender == _liquidityProvider, "user must claim own balance");
+        require(!claimed[_week][_liquidityProvider], "cannot claim twice");
+        require(verifyClaim(_liquidityProvider, _week, _claimedBalance, _merkleProof), "Incorrect merkle proof");
+
+        claimed[_week][_liquidityProvider] = true;
+        if (internalBalance) {
+            _disburseToInternalBalance(_liquidityProvider, _claimedBalance);
+        } else {
+            _disburse(_liquidityProvider, _claimedBalance);
+        }
+    }
+
+    struct Claim {
+        uint256 week;
+        uint256 balance;
+        bytes32[] merkleProof;
+    }
+
+    /**
+     * @notice Allows a user to claim a particular weeks worth of rewards
+     */
+    function claimWeeks(
+        address payable _liquidityProvider,
+        Claim[] memory claims,
+        bool useInternalBalance
+    ) public {
+        require(msg.sender == _liquidityProvider, "user must claim own balance");
+        uint256 totalBalance = 0;
+        Claim memory claim;
+        for (uint256 i = 0; i < claims.length; i++) {
+            claim = claims[i];
+
+            require(!claimed[claim.week][_liquidityProvider], "cannot claim twice");
+            require(
+                verifyClaim(_liquidityProvider, claim.week, claim.balance, claim.merkleProof),
+                "Incorrect merkle proof"
+            );
+
+            totalBalance += claim.balance;
+            claimed[claim.week][_liquidityProvider] = true;
+        }
+
+        if (useInternalBalance) {
+            _disburseToInternalBalance(_liquidityProvider, totalBalance);
+        } else {
+            _disburse(_liquidityProvider, totalBalance);
+        }
+    }
+
+    function claimStatus(
+        address _liquidityProvider,
+        uint256 _begin,
+        uint256 _end
+    ) external view returns (bool[] memory) {
+        require(_begin <= _end, "weeks must be specified in ascending order");
+        uint256 size = 1 + _end - _begin;
+        bool[] memory arr = new bool[](size);
+        for (uint256 i = 0; i < size; i++) {
+            arr[i] = claimed[_begin + i][_liquidityProvider];
+        }
+        return arr;
+    }
+
+    function merkleRoots(uint256 _begin, uint256 _end) external view returns (bytes32[] memory) {
+        require(_begin <= _end, "weeks must be specified in ascending order");
+        uint256 size = 1 + _end - _begin;
+        bytes32[] memory arr = new bytes32[](size);
+        for (uint256 i = 0; i < size; i++) {
+            arr[i] = weekMerkleRoots[_begin + i];
+        }
+        return arr;
+    }
+
+    function verifyClaim(
+        address _liquidityProvider,
+        uint256 _week,
+        uint256 _claimedBalance,
+        bytes32[] memory _merkleProof
+    ) public view returns (bool valid) {
+        bytes32 leaf = keccak256(abi.encodePacked(_liquidityProvider, _claimedBalance));
+        return MerkleProof.verify(_merkleProof, weekMerkleRoots[_week], leaf);
+    }
+
+    function seedAllocations(uint256 _week, bytes32 _merkleRoot) external onlyOwner {
+        require(weekMerkleRoots[_week] == bytes32(0), "cannot rewrite merkle root");
+        weekMerkleRoots[_week] = _merkleRoot;
+    }
+}

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -87,7 +87,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         rewardTokens.push(rewardsToken);
         rewardData[rewardsToken].rewardsDistributor = rewardsDistributor;
         rewardData[rewardsToken].rewardsDuration = rewardsDuration;
-        IERC20(rewardsToken).approve(address(vault), type(uint256).max);
+        rewardsToken.approve(address(vault), type(uint256).max);
     }
 
     /* ========== VIEWS ========== */
@@ -187,7 +187,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
             uint256 reward = rewards[msg.sender][rewardsToken];
             if (reward > 0) {
                 rewards[msg.sender][rewardsToken] = 0;
-                IERC20(rewardsToken).safeTransfer(msg.sender, reward);
+                rewardsToken.safeTransfer(msg.sender, reward);
                 emit RewardPaid(msg.sender, address(rewardsToken), reward);
             }
         }
@@ -236,7 +236,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         require(rewardData[rewardsToken].rewardsDistributor == msg.sender, "Callable only by distributor");
         // handle the transfer of reward tokens via `transferFrom` to reduce the number
         // of transactions required and ensure correctness of the reward amount
-        IERC20(rewardsToken).safeTransferFrom(msg.sender, address(this), reward);
+        rewardsToken.safeTransferFrom(msg.sender, address(this), reward);
 
         if (block.timestamp >= rewardData[rewardsToken].periodFinish) {
             rewardData[rewardsToken].rewardRate = reward.divDown(rewardData[rewardsToken].rewardsDuration);

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -82,6 +82,7 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         address rewardsDistributor,
         uint256 rewardsDuration
     ) public onlyOwner {
+        require(rewardsDuration > 0, "reward rate must be nonzero");
         require(rewardData[rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
         rewardTokens.push(rewardsToken);
         rewardData[rewardsToken].rewardsDistributor = rewardsDistributor;

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -40,8 +40,8 @@ contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, Temporari
         uint256 lastUpdateTime;
         uint256 rewardPerTokenStored;
     }
-    IVault public vault;
-    IERC20 public stakingToken;
+    IVault public immutable vault;
+    IERC20 public immutable stakingToken;
     mapping(IERC20 => Reward) public rewardData;
     IERC20[] public rewardTokens;
 

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -1,0 +1,265 @@
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Ownable.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+
+import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
+import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
+
+import "./interfaces/IRewardsContract.sol";
+
+// solhint-disable not-rely-on-time
+
+/**
+ * Balancer MultiRewards claim contract (claim to internal balance) based on
+ * Curve Finance's MultiRewards contract, updated to be compatible with solc 0.7.0
+ * https://github.com/curvefi/multi-rewards/blob/master/contracts/MultiRewards.sol commit #9947623
+ */
+
+contract MultiRewards is IRewardsContract, ReentrancyGuard, TemporarilyPausable, Ownable {
+    using FixedPoint for uint256;
+    using SafeERC20 for IERC20;
+
+    /* ========== STATE VARIABLES ========== */
+
+    struct Reward {
+        address rewardsDistributor;
+        uint256 rewardsDuration;
+        uint256 periodFinish;
+        uint256 rewardRate;
+        uint256 lastUpdateTime;
+        uint256 rewardPerTokenStored;
+    }
+    IVault public vault;
+    IERC20 public stakingToken;
+    mapping(address => Reward) public rewardData;
+    address[] public rewardTokens;
+
+    // user -> reward token -> amount
+    mapping(address => mapping(address => uint256)) public userRewardPerTokenPaid;
+    mapping(address => mapping(address => uint256)) public rewards;
+
+    uint256 private _totalSupply;
+    mapping(address => uint256) private _balances;
+
+    /* ========== CONSTRUCTOR ========== */
+
+    constructor(address _vault, address _stakingToken) Ownable() TemporarilyPausable(3600, 3600) {
+        vault = IVault(_vault);
+        stakingToken = IERC20(_stakingToken);
+    }
+
+    /**
+     * @notice Adds a new reward token to be distributed
+     * @param _rewardsToken - The new token to be distributed to stakers
+     * @param _rewardsDistributor - The address which is designated to add `_rewardsToken` to be distributed
+     * @param _rewardsDuration - The duration over which each distribution is spread
+     */
+    function addReward(
+        address _rewardsToken,
+        address _rewardsDistributor,
+        uint256 _rewardsDuration
+    ) public onlyOwner {
+        require(rewardData[_rewardsToken].rewardsDuration == 0, "Duplicate rewards token");
+        rewardTokens.push(_rewardsToken);
+        rewardData[_rewardsToken].rewardsDistributor = _rewardsDistributor;
+        rewardData[_rewardsToken].rewardsDuration = _rewardsDuration;
+        IERC20(_rewardsToken).approve(address(vault), type(uint256).max);
+    }
+
+    /* ========== VIEWS ========== */
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function lastTimeRewardApplicable(address _rewardsToken) public view returns (uint256) {
+        return Math.min(block.timestamp, rewardData[_rewardsToken].periodFinish);
+    }
+
+    function rewardPerToken(address _rewardsToken) public view returns (uint256) {
+        if (_totalSupply == 0) {
+            return rewardData[_rewardsToken].rewardPerTokenStored;
+        }
+        return
+            rewardData[_rewardsToken].rewardPerTokenStored.add(
+                lastTimeRewardApplicable(_rewardsToken)
+                    .sub(rewardData[_rewardsToken].lastUpdateTime)
+                    .mulDown(rewardData[_rewardsToken].rewardRate)
+                    .mulDown(1e18)
+                    .divDown(_totalSupply)
+            );
+    }
+
+    /**
+     * @notice Calculates the amount of `_rewardsToken` that `account` is able to claim
+     */
+    function earned(address account, address _rewardsToken) public view returns (uint256) {
+        return
+            _balances[account]
+                .mulDown(rewardPerToken(_rewardsToken).sub(userRewardPerTokenPaid[account][_rewardsToken]))
+                .divDown(1e18)
+                .add(rewards[account][_rewardsToken]);
+    }
+
+    function getRewardForDuration(address _rewardsToken) external view returns (uint256) {
+        return rewardData[_rewardsToken].rewardRate.mulDown(rewardData[_rewardsToken].rewardsDuration);
+    }
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    function setRewardsDistributor(address _rewardsToken, address _rewardsDistributor) external onlyOwner {
+        rewardData[_rewardsToken].rewardsDistributor = _rewardsDistributor;
+    }
+
+    function stake(uint256 amount) external {
+        stake(amount, msg.sender);
+    }
+
+    function stake(uint256 amount, address receiver) public nonReentrant whenNotPaused updateReward(receiver) {
+        require(amount > 0, "Cannot stake 0");
+        _totalSupply = _totalSupply.add(amount);
+        _balances[receiver] = _balances[receiver].add(amount);
+        stakingToken.safeTransferFrom(msg.sender, address(this), amount);
+        emit Staked(receiver, amount);
+    }
+
+    function withdraw(uint256 amount) public nonReentrant updateReward(msg.sender) {
+        require(amount > 0, "Cannot withdraw 0");
+        _totalSupply = _totalSupply.sub(amount);
+        _balances[msg.sender] = _balances[msg.sender].sub(amount);
+        stakingToken.safeTransfer(msg.sender, amount);
+        emit Withdrawn(msg.sender, amount);
+    }
+
+    /**
+     * @notice Allows a user to claim any rewards which are due.
+     */
+    function getReward() public nonReentrant updateReward(msg.sender) {
+        for (uint256 i; i < rewardTokens.length; i++) {
+            address _rewardsToken = rewardTokens[i];
+            uint256 reward = rewards[msg.sender][_rewardsToken];
+            if (reward > 0) {
+                rewards[msg.sender][_rewardsToken] = 0;
+                IERC20(_rewardsToken).safeTransfer(msg.sender, reward);
+                emit RewardPaid(msg.sender, _rewardsToken, reward);
+            }
+        }
+    }
+
+    /**
+     * @notice Allows a user to claim any rewards to internal balance
+     */
+    function getRewardAsInternalBalance() public nonReentrant updateReward(msg.sender) {
+        IVault.UserBalanceOp[] memory ops = new IVault.UserBalanceOp[](rewardTokens.length);
+
+        for (uint256 i; i < rewardTokens.length; i++) {
+            address _rewardsToken = rewardTokens[i];
+            uint256 reward = rewards[msg.sender][_rewardsToken];
+
+            if (reward > 0) {
+                rewards[msg.sender][_rewardsToken] = 0;
+
+                emit RewardPaid(msg.sender, _rewardsToken, reward);
+            }
+
+            ops[i] = IVault.UserBalanceOp({
+                asset: IAsset(_rewardsToken),
+                amount: reward,
+                sender: address(this),
+                recipient: msg.sender,
+                kind: IVault.UserBalanceOpKind.DEPOSIT_INTERNAL
+            });
+        }
+        vault.manageUserBalance(ops);
+    }
+
+    function exit() external {
+        withdraw(_balances[msg.sender]);
+        getReward();
+    }
+
+    /* ========== RESTRICTED FUNCTIONS ========== */
+
+    /**
+     * @notice Allows a rewards distributor to deposit more tokens to be distributed as rewards
+     * @param _rewardsToken - the token to deposit into staking contract for distribution
+     * @param reward - the amount of tokens to deposit
+     */
+    function notifyRewardAmount(address _rewardsToken, uint256 reward) external override updateReward(address(0)) {
+        require(rewardData[_rewardsToken].rewardsDistributor == msg.sender, "Callable only by distributor");
+        // handle the transfer of reward tokens via `transferFrom` to reduce the number
+        // of transactions required and ensure correctness of the reward amount
+        IERC20(_rewardsToken).safeTransferFrom(msg.sender, address(this), reward);
+
+        if (block.timestamp >= rewardData[_rewardsToken].periodFinish) {
+            rewardData[_rewardsToken].rewardRate = reward.divDown(rewardData[_rewardsToken].rewardsDuration);
+        } else {
+            uint256 remaining = rewardData[_rewardsToken].periodFinish.sub(block.timestamp);
+            uint256 leftover = remaining.mulDown(rewardData[_rewardsToken].rewardRate);
+            rewardData[_rewardsToken].rewardRate = reward.add(leftover).divDown(
+                rewardData[_rewardsToken].rewardsDuration
+            );
+        }
+
+        rewardData[_rewardsToken].lastUpdateTime = block.timestamp;
+        rewardData[_rewardsToken].periodFinish = block.timestamp.add(rewardData[_rewardsToken].rewardsDuration);
+        emit RewardAdded(reward);
+    }
+
+    /**
+     * @notice
+     * Allows the owner to recover any extra tokens sent to this address.
+     * Added to support recovering LP Rewards from other systems to be distributed to holders
+     * @param tokenAddress - the token to recover (cannot be staking or reward token)
+     * @param tokenAmount - the amount of tokens to withdraw
+     */
+    function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyOwner {
+        require(tokenAddress != address(stakingToken), "Cannot withdraw staking token");
+        require(rewardData[tokenAddress].lastUpdateTime == 0, "Cannot withdraw reward token");
+        IERC20(tokenAddress).safeTransfer(owner(), tokenAmount);
+        emit Recovered(tokenAddress, tokenAmount);
+    }
+
+    function setRewardsDuration(address _rewardsToken, uint256 _rewardsDuration) external {
+        require(block.timestamp > rewardData[_rewardsToken].periodFinish, "Reward period still active");
+        require(rewardData[_rewardsToken].rewardsDistributor == msg.sender, "Callable only by distributor");
+        require(_rewardsDuration > 0, "Reward duration must be non-zero");
+        rewardData[_rewardsToken].rewardsDuration = _rewardsDuration;
+        emit RewardsDurationUpdated(_rewardsToken, rewardData[_rewardsToken].rewardsDuration);
+    }
+
+    /* ========== MODIFIERS ========== */
+
+    modifier updateReward(address account) {
+        for (uint256 i; i < rewardTokens.length; i++) {
+            address token = rewardTokens[i];
+            rewardData[token].rewardPerTokenStored = rewardPerToken(token);
+            rewardData[token].lastUpdateTime = lastTimeRewardApplicable(token);
+            if (account != address(0)) {
+                rewards[account][token] = earned(account, token);
+                userRewardPerTokenPaid[account][token] = rewardData[token].rewardPerTokenStored;
+            }
+        }
+        _;
+    }
+
+    /* ========== EVENTS ========== */
+
+    event RewardAdded(uint256 reward);
+    event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+    event RewardPaid(address indexed user, address indexed rewardsToken, uint256 reward);
+    event RewardsDurationUpdated(address token, uint256 newDuration);
+    event Recovered(address token, uint256 amount);
+}

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
@@ -13,7 +15,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20Permit.sol
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
 
-import "./interfaces/IRewardsContract.sol";
+import "./interfaces/IMultiRewards.sol";
+import "./interfaces/IDistributor.sol";
 
 // solhint-disable not-rely-on-time
 
@@ -23,7 +26,7 @@ import "./interfaces/IRewardsContract.sol";
  * https://github.com/curvefi/multi-rewards/blob/master/contracts/MultiRewards.sol commit #9947623
  */
 
-contract MultiRewards is IRewardsContract, ReentrancyGuard, TemporarilyPausable, Ownable {
+contract MultiRewards is IMultiRewards, IDistributor, ReentrancyGuard, TemporarilyPausable, Ownable {
     using FixedPoint for uint256;
     using SafeERC20 for IERC20;
 
@@ -234,7 +237,7 @@ contract MultiRewards is IRewardsContract, ReentrancyGuard, TemporarilyPausable,
 
         rewardData[_rewardsToken].lastUpdateTime = block.timestamp;
         rewardData[_rewardsToken].periodFinish = block.timestamp.add(rewardData[_rewardsToken].rewardsDuration);
-        emit RewardAdded(reward);
+        emit RewardAdded(_rewardsToken, reward);
     }
 
     /**
@@ -276,10 +279,8 @@ contract MultiRewards is IRewardsContract, ReentrancyGuard, TemporarilyPausable,
 
     /* ========== EVENTS ========== */
 
-    event RewardAdded(uint256 reward);
     event Staked(address indexed user, uint256 amount);
     event Withdrawn(address indexed user, uint256 amount);
-    event RewardPaid(address indexed user, address indexed rewardsToken, uint256 reward);
     event RewardsDurationUpdated(address token, uint256 newDuration);
     event Recovered(address token, uint256 amount);
 }

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -1,4 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;

--- a/pkg/distributors/contracts/MultiRewards.sol
+++ b/pkg/distributors/contracts/MultiRewards.sol
@@ -8,6 +8,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/TemporarilyPausable.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20Permit.sol";
 
 import "@balancer-labs/v2-vault/contracts/interfaces/IVault.sol";
 import "@balancer-labs/v2-vault/contracts/interfaces/IAsset.sol";
@@ -132,6 +133,25 @@ contract MultiRewards is IRewardsContract, ReentrancyGuard, TemporarilyPausable,
         _balances[receiver] = _balances[receiver].add(amount);
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
         emit Staked(receiver, amount);
+    }
+
+    /**
+     * @notice Stake tokens using a permit signature for approval
+     * @param amount    Amount of allowance
+     * @param deadline  The time at which this expires (unix time)
+     * @param v         v of the signature
+     * @param r         r of the signature
+     * @param s         s of the signature
+     */
+    function stakeWithPermit(
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20Permit(address(stakingToken)).permit(msg.sender, address(this), amount, deadline, v, r, s);
+        stake(amount, msg.sender);
     }
 
     function withdraw(uint256 amount) public nonReentrant updateReward(msg.sender) {

--- a/pkg/distributors/contracts/interfaces/IDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IDistributor.sol
@@ -16,5 +16,5 @@ pragma solidity ^0.7.0;
 
 interface IDistributor {
     event RewardAdded(address indexed token, uint256 amount);
-    event RewardPaid(address indexed user, address indexed rewardsToken, uint256 reward);
+    event RewardPaid(address indexed user, address indexed rewardToken, uint256 amount);
 }

--- a/pkg/distributors/contracts/interfaces/IDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IDistributor.sol
@@ -1,4 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
 

--- a/pkg/distributors/contracts/interfaces/IDistributor.sol
+++ b/pkg/distributors/contracts/interfaces/IDistributor.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity ^0.7.0;
+
+interface IDistributor {
+    event RewardAdded(address indexed token, uint256 amount);
+    event RewardPaid(address indexed user, address indexed rewardsToken, uint256 reward);
+}

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pragma solidity ^0.7.0;
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
 interface IMultiRewards {
-    function notifyRewardAmount(address _rewardsToken, uint256 reward) external;
+    function notifyRewardAmount(IERC20 _rewardsToken, uint256 reward) external;
 }

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -1,6 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;
+
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/IERC20.sol";
 
 interface IMultiRewards {

--- a/pkg/distributors/contracts/interfaces/IMultiRewards.sol
+++ b/pkg/distributors/contracts/interfaces/IMultiRewards.sol
@@ -1,5 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pragma solidity ^0.7.0;
 
-interface IRewardsContract {
+interface IMultiRewards {
     function notifyRewardAmount(address _rewardsToken, uint256 reward) external;
 }

--- a/pkg/distributors/contracts/interfaces/IRewardsContract.sol
+++ b/pkg/distributors/contracts/interfaces/IRewardsContract.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.7.0;
+
+interface IRewardsContract {
+    function notifyRewardAmount(address _rewardsToken, uint256 reward) external;
+}

--- a/pkg/distributors/hardhat.config.ts
+++ b/pkg/distributors/hardhat.config.ts
@@ -1,0 +1,23 @@
+import '@nomiclabs/hardhat-ethers';
+import '@nomiclabs/hardhat-waffle';
+
+import { hardhatBaseConfig } from '@balancer-labs/v2-common';
+import { name } from './package.json';
+
+import { task } from 'hardhat/config';
+import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
+import overrideQueryFunctions from '@balancer-labs/v2-helpers/plugins/overrideQueryFunctions';
+
+task(TASK_COMPILE).setAction(overrideQueryFunctions);
+
+export default {
+  networks: {
+    hardhat: {
+      allowUnlimitedContractSize: true,
+    },
+  },
+  solidity: {
+    compilers: hardhatBaseConfig.compilers,
+    overrides: { ...hardhatBaseConfig.overrides(name) },
+  },
+};

--- a/pkg/distributors/lib/merkleTree.ts
+++ b/pkg/distributors/lib/merkleTree.ts
@@ -1,0 +1,144 @@
+import { keccak256, keccakFromString, bufferToHex } from 'ethereumjs-util';
+import { utils } from 'ethers';
+
+/* eslint-disable */
+
+// Merkle tree called with 32 byte hex values
+export class MerkleTree {
+  elements: Buffer[];
+  layers: any[];
+
+  constructor(elements: string[]) {
+    this.elements = elements.filter((el) => el).map((el) => Buffer.from(utils.arrayify(el)));
+
+    // Sort elements
+    this.elements.sort(Buffer.compare);
+    // Deduplicate elements
+    this.elements = this.bufDedup(this.elements);
+
+    // Create layers
+    this.layers = this.getLayers(this.elements);
+  }
+
+  getLayers(elements: Buffer[]) {
+    if (elements.length === 0) {
+      return [['']];
+    }
+
+    const layers: any[] = [];
+    layers.push(elements);
+
+    // Get next layer until we reach the root
+    while (layers[layers.length - 1].length > 1) {
+      layers.push(this.getNextLayer(layers[layers.length - 1]));
+    }
+
+    return layers;
+  }
+
+  getNextLayer(elements: Buffer[]) {
+    return elements.reduce((layer: any, el: any, idx: number, arr: any[]) => {
+      if (idx % 2 === 0) {
+        // Hash the current element with its pair element
+        layer.push(this.combinedHash(el, arr[idx + 1]));
+      }
+
+      return layer;
+    }, []);
+  }
+
+  combinedHash(first: string, second: string): Buffer | String {
+    if (!first) {
+      return second;
+    }
+    if (!second) {
+      return first;
+    }
+
+    return keccak256(this.sortAndConcat(first, second));
+  }
+
+  getRoot() {
+    return this.layers[this.layers.length - 1][0];
+  }
+
+  getHexRoot() {
+    return bufferToHex(this.getRoot());
+  }
+
+  getProof(el: Buffer) {
+    let idx = this.bufIndexOf(el, this.elements);
+
+    if (idx === -1) {
+      throw new Error('Element does not exist in Merkle tree');
+    }
+
+    return this.layers.reduce((proof, layer) => {
+      const pairElement = this.getPairElement(idx, layer);
+
+      if (pairElement) {
+        proof.push(pairElement);
+      }
+
+      idx = Math.floor(idx / 2);
+
+      return proof;
+    }, []);
+  }
+
+  // external call - convert to buffer
+  getHexProof(_el: any) {
+    const el = Buffer.from(utils.arrayify(_el));
+
+    const proof = this.getProof(el);
+
+    return this.bufArrToHexArr(proof);
+  }
+
+  getPairElement(idx: number, layer: any) {
+    const pairIdx = idx % 2 === 0 ? idx + 1 : idx - 1;
+
+    if (pairIdx < layer.length) {
+      return layer[pairIdx];
+    } else {
+      return null;
+    }
+  }
+
+  bufIndexOf(el: Buffer | string, arr: Buffer[]) {
+    let hash;
+
+    // Convert element to 32 byte hash if it is not one already
+    if (el.length !== 32 || !Buffer.isBuffer(el)) {
+      hash = keccakFromString(el as string);
+    } else {
+      hash = el as Buffer;
+    }
+
+    for (let i = 0; i < arr.length; i++) {
+      if (hash.equals(arr[i])) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  bufDedup(elements: Buffer[]) {
+    return elements.filter((el, idx: number) => {
+      return idx === 0 || !elements[idx - 1].equals(el);
+    });
+  }
+
+  bufArrToHexArr(arr: Buffer[]) {
+    if (arr.some((el) => !Buffer.isBuffer(el))) {
+      throw new Error('Array is not an array of buffers');
+    }
+
+    return arr.map((el: Buffer) => '0x' + el.toString('hex'));
+  }
+
+  sortAndConcat(...args: any[]) {
+    return Buffer.concat([...args].sort(Buffer.compare));
+  }
+}

--- a/pkg/distributors/package.json
+++ b/pkg/distributors/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@balancer-labs/v2-distributors",
+  "version": "0.1.0",
+  "description": "Utilities for distributing tokens from internal balance",
+  "license": "GPL-3.0-only",
+  "homepage": "https://github.com/balancer-labs/balancer-core-v2#readme",
+  "repository": "git@github.com:balancer-labs/balancer-core-v2.git",
+  "bugs": {
+    "url": "https://github.com/balancer-labs/balancer-core-v2/issues"
+  },
+  "contributors": [
+    "Greg Taschuk <greg@balancer.finance>",
+    "Tom French <tom@balancer.finance>"
+  ],
+  "scripts": {
+    "build": "yarn compile",
+    "compile": "hardhat compile && rm -rf artifacts/build-info",
+    "compile:watch": "nodemon --ext sol --exec yarn compile",
+    "lint": "yarn lint:solidity && yarn lint:typescript",
+    "lint:solidity": "solhint 'contracts/**/*.sol'",
+    "lint:typescript": "eslint --max-warnings 0 . --ext .ts",
+    "test": "yarn compile && mocha --extension ts --require hardhat/register --require @balancer-labs/v2-common/setupTests --recursive",
+    "test:fast": "yarn compile && mocha --extension ts --require hardhat/register --require @balancer-labs/v2-common/setupTests --recursive --parallel --exit",
+    "test:watch": "nodemon --ext js,ts --watch test --watch lib --exec 'clear && yarn test --no-compile'"
+  },
+  "devDependencies": {
+    "@balancer-labs/v2-common": "workspace:*",
+    "@balancer-labs/v2-helpers": "workspace:*",
+    "@balancer-labs/v2-pool-utils": "workspace:*",
+    "@balancer-labs/v2-solidity-utils": "workspace:*",
+    "@balancer-labs/v2-standalone-utils": "workspace:*",
+    "@balancer-labs/v2-vault": "workspace:*",
+    "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "@nomiclabs/hardhat-waffle": "^2.0.0",
+    "@types/chai": "^4.2.12",
+    "@types/lodash": "^4.14.161",
+    "@types/mocha": "^8.0.3",
+    "@types/node": "^14.6.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
+    "chai": "^4.2.0",
+    "decimal.js": "^10.2.1",
+    "eslint": "^7.9.0",
+    "eslint-plugin-mocha-no-only": "^1.1.1",
+    "eslint-plugin-prettier": "^3.1.4",
+    "ethereum-waffle": "^3.0.2",
+    "ethers": "^5.0.18",
+    "hardhat": "^2.2.0",
+    "lodash.frompairs": "^4.0.1",
+    "lodash.pick": "^4.4.0",
+    "lodash.range": "^3.2.0",
+    "lodash.times": "^4.3.2",
+    "lodash.zip": "^4.2.0",
+    "mocha": "^8.2.1",
+    "nodemon": "^2.0.4",
+    "prettier": "^2.1.2",
+    "prettier-plugin-solidity": "v1.0.0-alpha.59",
+    "solhint": "^3.2.0",
+    "solhint-plugin-prettier": "^0.0.4",
+    "ts-node": "^8.10.2",
+    "typescript": "^4.0.2"
+  }
+}

--- a/pkg/distributors/package.json
+++ b/pkg/distributors/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-mocha-no-only": "^1.1.1",
     "eslint-plugin-prettier": "^3.1.4",
     "ethereum-waffle": "^3.0.2",
+    "ethereumjs-util": "^7.0.10",
     "ethers": "^5.0.18",
     "hardhat": "^2.2.0",
     "lodash.frompairs": "^4.0.1",

--- a/pkg/distributors/test/MerkleRedeem.test.ts
+++ b/pkg/distributors/test/MerkleRedeem.test.ts
@@ -1,0 +1,272 @@
+import { ethers } from 'hardhat';
+import { BytesLike, BigNumber } from 'ethers';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { GeneralPool } from '@balancer-labs/v2-helpers/src/models/vault/pools';
+import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
+
+import { bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { MerkleTree } from '../lib/merkleTree';
+
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+function encodeElement(address: string, balance: BigNumber): string {
+  return ethers.utils.solidityKeccak256(['address', 'uint'], [address, balance]);
+}
+
+describe('MerkleRedeem', () => {
+  let tokens: TokenList,
+    rewardTokens: TokenList,
+    rewardToken: Token,
+    vault: Contract,
+    authorizer: Contract,
+    merkleRedeem: Contract;
+
+  let admin: SignerWithAddress,
+    lp1: SignerWithAddress,
+    lp2: SignerWithAddress,
+    lp3: SignerWithAddress,
+    mockAssetManager: SignerWithAddress;
+  let poolId: string;
+  const rewardTokenInitialBalance = bn(100e18);
+  const tokenInitialBalance = bn(200e18);
+
+  before('deploy base contracts', async () => {
+    [admin, lp1, lp2, lp3, mockAssetManager] = await ethers.getSigners();
+  });
+
+  beforeEach('set up tokens and redeem contract', async () => {
+    tokens = await TokenList.create(['SNX', 'MKR'], { sorted: true });
+
+    rewardTokens = await TokenList.create(['DAI'], { sorted: true });
+    rewardToken = rewardTokens.DAI;
+
+    // Deploy Balancer Vault
+    authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+    vault = await deploy('v2-vault/Vault', { args: [authorizer.address, tokens.SNX.address, 0, 0] });
+
+    merkleRedeem = await deploy('MerkleRedeem', {
+      args: [vault.address, rewardToken.address],
+    });
+    await rewardTokens.mint({ to: merkleRedeem.address, amount: rewardTokenInitialBalance });
+
+    // deploy pool and add liquidity
+    const specialization = GeneralPool;
+    const pool = await deploy('v2-vault/MockPool', { args: [vault.address, specialization] });
+    poolId = await pool.getPoolId();
+
+    await tokens.mint({ to: lp1, amount: tokenInitialBalance });
+    await tokens.approve({ to: vault.address, from: [lp1] });
+
+    const assets = tokens.addresses;
+    const assetManagers = [mockAssetManager.address, mockAssetManager.address];
+    await pool.registerTokens(assets, assetManagers);
+
+    await vault.connect(lp1).joinPool(poolId, lp1.address, lp2.address, {
+      assets,
+      maxAmountsIn: assets.map(() => MAX_UINT256),
+      fromInternalBalance: false,
+      userData: encodeJoin(
+        assets.map(() => tokenInitialBalance),
+        assets.map(() => 0)
+      ),
+    });
+  });
+
+  it('stores an allocation', async () => {
+    const claimBalance = bn('9876');
+
+    const elements = [encodeElement(lp1.address, claimBalance)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await merkleRedeem.connect(admin).seedAllocations(bn(1), root);
+
+    const proof = merkleTree.getHexProof(elements[0]);
+
+    const result = await merkleRedeem.verifyClaim(lp1.address, 1, claimBalance, proof);
+    expect(result).to.equal(true);
+  });
+
+  it("doesn't allow an allocation to be overwritten", async () => {
+    const claimBalance = bn('9876');
+
+    const elements = [encodeElement(lp1.address, claimBalance)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await merkleRedeem.seedAllocations(1, root);
+
+    // construct tree to attempt to override the allocation
+    const elements2 = [encodeElement(lp1.address, claimBalance), encodeElement(lp2.address, claimBalance)];
+    const merkleTree2 = new MerkleTree(elements2);
+    const root2 = merkleTree2.getHexRoot();
+
+    const errorMsg = 'cannot rewrite merkle root';
+    expect(merkleRedeem.seedAllocations(1, root2)).to.be.revertedWith(errorMsg);
+  });
+
+  it('stores multiple allocations', async () => {
+    const claimBalance0 = bn('1000');
+    const claimBalance1 = bn('2000');
+
+    const elements = [encodeElement(lp1.address, claimBalance0), encodeElement(lp2.address, claimBalance1)];
+    const merkleTree = new MerkleTree(elements);
+    const root = merkleTree.getHexRoot();
+
+    await merkleRedeem.seedAllocations(1, root);
+
+    const proof0 = merkleTree.getHexProof(elements[0]);
+    let result = await merkleRedeem.verifyClaim(lp1.address, 1, claimBalance0, proof0);
+    expect(result).to.equal(true); //"account 0 should have an allocation";
+
+    const proof1 = merkleTree.getHexProof(elements[1]);
+    result = await merkleRedeem.verifyClaim(lp2.address, 1, claimBalance1, proof1);
+    expect(result).to.equal(true); // "account 1 should have an allocation";
+  });
+
+  describe('When a user has an allocation to claim', () => {
+    const claimBalance = bn('1000');
+    let elements: string[];
+    let merkleTree: MerkleTree;
+
+    beforeEach(async () => {
+      elements = [encodeElement(lp2.address, claimBalance)];
+      merkleTree = new MerkleTree(elements);
+      const root = merkleTree.getHexRoot();
+
+      await merkleRedeem.seedAllocations(1, root);
+    });
+
+    it('Allows the user to claimWeek', async () => {
+      const claimedBalance = bn('1000');
+      const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
+      await merkleRedeem.connect(lp2).claimWeek(lp2.address, 1, claimedBalance, merkleProof, false);
+
+      const result = await rewardToken.balanceOf(lp2.address);
+      expect(result).to.equal(claimedBalance); //"user should have an allocation";
+
+      const isClaimed = await merkleRedeem.claimed(1, lp2.address);
+      expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
+    });
+
+    it('Allows the user to claimWeek to internal balance', async () => {
+      const claimedBalance = bn('1000');
+      const merkleProof: BytesLike[] = merkleTree.getHexProof(elements[0]);
+
+      await expectBalanceChange(
+        () => merkleRedeem.connect(lp2).claimWeek(lp2.address, 1, claimedBalance, merkleProof, true),
+        rewardTokens,
+        [{ account: lp2, changes: { DAI: claimedBalance } }],
+        vault
+      );
+
+      const isClaimed = await merkleRedeem.claimed(1, lp2.address);
+      expect(isClaimed).to.equal(true); // "claim should be marked as claimed";
+    });
+
+    it("Doesn't allow a user to claim for another user", async () => {
+      const claimedBalance = bn('1000');
+      const merkleProof = merkleTree.getHexProof(elements[0]);
+
+      const errorMsg = 'Incorrect merkle proof';
+      expect(
+        merkleRedeem.connect(lp3).claimWeek(lp3.address, 1, claimedBalance, merkleProof, false)
+      ).to.be.revertedWith(errorMsg);
+    });
+
+    it('Reverts when the user attempts to claim the wrong balance', async () => {
+      const claimedBalance = bn('666');
+      const merkleProof = merkleTree.getHexProof(elements[0]);
+      const errorMsg = 'Incorrect merkle proof';
+      expect(
+        merkleRedeem.connect(lp2).claimWeek(lp2.address, 1, claimedBalance, merkleProof, false)
+      ).to.be.revertedWith(errorMsg);
+    });
+
+    it('Reverts when the user attempts to claim twice', async () => {
+      const claimedBalance = bn('1000');
+      const merkleProof = merkleTree.getHexProof(elements[0]);
+
+      await merkleRedeem.connect(lp2).claimWeek(lp2.address, 1, claimedBalance, merkleProof, false);
+
+      const errorMsg = 'cannot claim twice';
+      expect(
+        merkleRedeem.connect(lp2).claimWeek(lp2.address, 1, claimedBalance, merkleProof, false)
+      ).to.be.revertedWith(errorMsg);
+    });
+  });
+
+  describe('When a user has several allocation to claim', () => {
+    const claimBalance1 = bn('1000');
+    const claimBalance2 = bn('1234');
+
+    let elements1: string[];
+    let merkleTree1: MerkleTree;
+    let root1: string;
+
+    let elements2: string[];
+    let merkleTree2: MerkleTree;
+    let root2: string;
+
+    beforeEach(async () => {
+      elements1 = [encodeElement(lp2.address, claimBalance1)];
+      merkleTree1 = new MerkleTree(elements1);
+      root1 = merkleTree1.getHexRoot();
+
+      elements2 = [encodeElement(lp2.address, claimBalance2)];
+      merkleTree2 = new MerkleTree(elements2);
+      root2 = merkleTree2.getHexRoot();
+
+      await merkleRedeem.seedAllocations(bn(1), root1);
+
+      await merkleRedeem.seedAllocations(bn(2), root2);
+    });
+
+    it('Allows the user to claim multiple weeks at once', async () => {
+      const claimedBalance1 = bn('1000');
+      const claimedBalance2 = bn('1234');
+
+      const proof1: BytesLike[] = merkleTree1.getHexProof(elements1[0]);
+      const proof2: BytesLike[] = merkleTree2.getHexProof(elements2[0]);
+
+      const merkleProofs = [
+        { week: bn(1), balance: claimedBalance1, merkleProof: proof1 },
+        { week: bn(2), balance: claimedBalance2, merkleProof: proof2 },
+      ];
+
+      await merkleRedeem.connect(lp2).claimWeeks(lp2.address, merkleProofs, false);
+
+      const result = await rewardToken.balanceOf(lp2.address);
+      expect(result).to.equal(bn('2234')); //"user should receive all tokens, including current week"
+    });
+
+    it('Returns an array of week claims', async () => {
+      let expectedResult = [false, false];
+      let result = await merkleRedeem.claimStatus(lp2.address, 1, 2);
+      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+      const claimedBalance1 = bn('1000');
+      const proof1 = merkleTree1.getHexProof(elements1[0]);
+
+      const merkleProofs = [{ week: bn(1), balance: claimedBalance1, merkleProof: proof1 }];
+
+      await merkleRedeem.connect(lp2).claimWeeks(lp2.address, merkleProofs, false);
+
+      expectedResult = [true, false];
+      result = await merkleRedeem.claimStatus(lp2.address, 1, 2);
+      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+    });
+
+    it('Returns an array of merkle roots', async () => {
+      const expectedResult = [root1, root2];
+      const result = await merkleRedeem.merkleRoots(1, 2);
+      expect(result).to.eql(expectedResult); // "claim status should be accurate"
+    });
+  });
+});

--- a/pkg/distributors/test/MultiRewards.test.ts
+++ b/pkg/distributors/test/MultiRewards.test.ts
@@ -1,0 +1,191 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import Token from '@balancer-labs/v2-helpers/src/models/tokens/Token';
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+
+import { bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
+import { encodeJoinWeightedPool } from '@balancer-labs/v2-helpers/src/models/pools/weighted/encoding';
+import { advanceTime } from '@balancer-labs/v2-helpers/src/time';
+
+const tokenInitialBalance = bn(200e18);
+const rewardTokenInitialBalance = bn(100e18);
+
+const setup = async () => {
+  const [, admin, lp, mockAssetManager] = await ethers.getSigners();
+
+  const tokens = await TokenList.create(['SNX', 'MKR'], { sorted: true });
+  const rewardTokens = await TokenList.create(['DAI'], { sorted: true });
+
+  // Deploy Balancer Vault
+  const authorizer = await deploy('v2-vault/Authorizer', { args: [admin.address] });
+  const vault = await deploy('v2-vault/Vault', { args: [authorizer.address, tokens.SNX.address, 0, 0] });
+
+  const pool = await deploy('v2-pool-weighted/WeightedPool', {
+    args: [vault.address, 'Test Pool', 'TEST', tokens.addresses, [fp(0.5), fp(0.5)], fp(0.0001), 0, 0, admin.address],
+  });
+
+  const poolId = await pool.getPoolId();
+
+  // Deploy staking contract for pool
+  const stakingContract = await deploy('MultiRewards', {
+    args: [vault.address, pool.address],
+  });
+
+  const rewardToken = rewardTokens.DAI;
+
+  const rewardsDuration = 1; // Have a neglibile duration so that rewards are distributed instantaneously
+  await stakingContract.addReward(rewardToken.address, mockAssetManager.address, rewardsDuration);
+
+  await tokens.mint({ to: lp, amount: tokenInitialBalance });
+  await tokens.approve({ to: vault.address, from: [lp] });
+
+  await rewardTokens.mint({ to: mockAssetManager, amount: rewardTokenInitialBalance });
+  await rewardTokens.approve({ to: stakingContract.address, from: [mockAssetManager] });
+
+  const assets = tokens.addresses;
+
+  await vault.connect(lp).joinPool(poolId, lp.address, lp.address, {
+    assets,
+    maxAmountsIn: Array(assets.length).fill(MAX_UINT256),
+    fromInternalBalance: false,
+    userData: encodeJoinWeightedPool({
+      kind: 'Init',
+      amountsIn: Array(assets.length).fill(tokenInitialBalance),
+    }),
+  });
+
+  return {
+    data: {
+      poolId,
+    },
+    contracts: {
+      tokens,
+      rewardTokens,
+      pool,
+      stakingContract,
+      vault,
+    },
+  };
+};
+
+describe('Staking contract', () => {
+  let lp: SignerWithAddress, other: SignerWithAddress, mockAssetManager: SignerWithAddress;
+
+  let rewardTokens: TokenList;
+  let vault: Contract;
+  let stakingContract: Contract;
+  let rewardToken: Token;
+  let pool: Contract;
+
+  before('deploy base contracts', async () => {
+    [, , lp, mockAssetManager, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('set up asset manager', async () => {
+    const { contracts } = await setup();
+
+    pool = contracts.pool;
+    vault = contracts.vault;
+    stakingContract = contracts.stakingContract;
+    rewardToken = contracts.rewardTokens.DAI;
+    rewardTokens = contracts.rewardTokens;
+  });
+
+  before(async () => {
+    [, , lp, other] = await ethers.getSigners();
+  });
+
+  describe('with two stakes', () => {
+    const rewardAmount = fp(1);
+
+    beforeEach(async () => {
+      const bptBalance = await pool.balanceOf(lp.address);
+
+      await pool.connect(lp).approve(stakingContract.address, bptBalance);
+
+      // Stake 3/4 of the bpt to the LP and 1/4 to another address
+      await stakingContract.connect(lp)['stake(uint256)'](bptBalance.mul(3).div(4));
+      await stakingContract.connect(lp)['stake(uint256,address)'](bptBalance.div(4), other.address);
+    });
+
+    it('sends expected amount of reward token to the rewards contract', async () => {
+      const rewardsBefore = await rewardToken.balanceOf(stakingContract.address);
+
+      await expectBalanceChange(
+        () => stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, rewardAmount),
+        rewardTokens,
+        [{ account: stakingContract, changes: { DAI: rewardAmount } }]
+      );
+
+      const rewardsAfter = await rewardToken.balanceOf(stakingContract.address);
+      expect(rewardsAfter).to.be.eq(rewardsBefore.add(rewardAmount));
+    });
+
+    it('distributes the reward according to the fraction of staked LP tokens', async () => {
+      await stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, rewardAmount);
+      await advanceTime(10);
+
+      // 3/4 share
+      const expectedReward = fp(0.75);
+      const actualReward = await stakingContract.earned(lp.address, rewardToken.address);
+
+      expect(expectedReward.sub(actualReward).abs()).to.be.lte(100);
+
+      // 1/4 share
+      const expectedRewardOther = fp(0.25);
+      const actualRewardOther = await stakingContract.earned(other.address, rewardToken.address);
+
+      expect(expectedRewardOther.sub(actualRewardOther).abs()).to.be.lte(100);
+    });
+
+    it('allows a user to claim the reward to an EOA', async () => {
+      await stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, rewardAmount);
+      await advanceTime(10);
+
+      const expectedReward = fp(0.75);
+
+      await expectBalanceChange(() => stakingContract.connect(lp).getReward(), rewardTokens, [
+        { account: lp, changes: { DAI: ['very-near', expectedReward] } },
+      ]);
+    });
+
+    it('allows a user to claim the reward to internal balance', async () => {
+      await stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, rewardAmount);
+      await advanceTime(10);
+
+      const expectedReward = fp(0.75);
+
+      await expectBalanceChange(
+        () => stakingContract.connect(lp).getRewardAsInternalBalance(),
+        rewardTokens,
+        [{ account: lp, changes: { DAI: ['very-near', expectedReward] } }],
+        vault
+      );
+    });
+
+    describe('with a second distribution', () => {
+      const secondRewardAmount = fp(2);
+
+      beforeEach(async () => {
+        await stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, rewardAmount);
+        await stakingContract.connect(mockAssetManager).notifyRewardAmount(rewardToken.address, secondRewardAmount);
+        // total reward = fp(3)
+      });
+
+      it('distributes the reward from both distributions', async () => {
+        const expectedReward = fp(0.75).mul(3);
+        await advanceTime(10);
+
+        const actualReward = await stakingContract.earned(lp.address, rewardToken.address);
+        expect(expectedReward.sub(actualReward).abs()).to.be.lte(300);
+      });
+    });
+  });
+});

--- a/pkg/distributors/tsconfig.json
+++ b/pkg/distributors/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}

--- a/pkg/solidity-utils/contracts/openzeppelin/MerkleProof.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/MerkleProof.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev These functions deal with verification of Merkle trees (hash trees),
+ */
+library MerkleProof {
+    /**
+     * @dev Returns true if a `leaf` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     */
+    function verify(bytes32[] memory proof, bytes32 root, bytes32 leaf) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash <= proofElement) {
+                // Hash(current computed hash + current element of the proof)
+                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+            } else {
+                // Hash(current element of the proof + current computed hash)
+                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+            }
+        }
+
+        // Check if the computed hash (root) is equal to the provided root
+        return computedHash == root;
+    }
+}

--- a/pkg/solidity-utils/contracts/openzeppelin/Ownable.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/Ownable.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+
+// Based on the Ownable library from OpenZeppelin Contracts, altered to reduce runtime gas by dropping
+// support for the GSN.
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () {
+        _owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/pvt/helpers/src/models/misc/signatures.ts
+++ b/pvt/helpers/src/models/misc/signatures.ts
@@ -125,7 +125,7 @@ export async function signAuthorizationFor(
 export async function signPermit(
   token: Contract,
   owner: SignerWithAddress,
-  spender: SignerWithAddress,
+  spender: SignerWithAddress | Contract,
   amount: BigNumberish,
   nonce?: BigNumberish,
   deadline?: BigNumberish

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,48 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@balancer-labs/v2-distributors@workspace:pkg/distributors":
+  version: 0.0.0-use.local
+  resolution: "@balancer-labs/v2-distributors@workspace:pkg/distributors"
+  dependencies:
+    "@balancer-labs/v2-common": "workspace:*"
+    "@balancer-labs/v2-helpers": "workspace:*"
+    "@balancer-labs/v2-pool-utils": "workspace:*"
+    "@balancer-labs/v2-solidity-utils": "workspace:*"
+    "@balancer-labs/v2-standalone-utils": "workspace:*"
+    "@balancer-labs/v2-vault": "workspace:*"
+    "@nomiclabs/hardhat-ethers": ^2.0.1
+    "@nomiclabs/hardhat-waffle": ^2.0.0
+    "@types/chai": ^4.2.12
+    "@types/lodash": ^4.14.161
+    "@types/mocha": ^8.0.3
+    "@types/node": ^14.6.0
+    "@typescript-eslint/eslint-plugin": ^4.1.1
+    "@typescript-eslint/parser": ^4.1.1
+    chai: ^4.2.0
+    decimal.js: ^10.2.1
+    eslint: ^7.9.0
+    eslint-plugin-mocha-no-only: ^1.1.1
+    eslint-plugin-prettier: ^3.1.4
+    ethereum-waffle: ^3.0.2
+    ethers: ^5.0.18
+    hardhat: ^2.2.0
+    lodash.frompairs: ^4.0.1
+    lodash.pick: ^4.4.0
+    lodash.range: ^3.2.0
+    lodash.times: ^4.3.2
+    lodash.zip: ^4.2.0
+    mocha: ^8.2.1
+    nodemon: ^2.0.4
+    prettier: ^2.1.2
+    prettier-plugin-solidity: v1.0.0-alpha.59
+    solhint: ^3.2.0
+    solhint-plugin-prettier: ^0.0.4
+    ts-node: ^8.10.2
+    typescript: ^4.0.2
+  languageName: unknown
+  linkType: soft
+
 "@balancer-labs/v2-helpers@workspace:*, @balancer-labs/v2-helpers@workspace:pvt/helpers":
   version: 0.0.0-use.local
   resolution: "@balancer-labs/v2-helpers@workspace:pvt/helpers"

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,7 @@ __metadata:
     eslint-plugin-mocha-no-only: ^1.1.1
     eslint-plugin-prettier: ^3.1.4
     ethereum-waffle: ^3.0.2
+    ethereumjs-util: ^7.0.10
     ethers: ^5.0.18
     hardhat: ^2.2.0
     lodash.frompairs: ^4.0.1


### PR DESCRIPTION
This adds two implementations of a `Distributor` - a contract that distributes tokens such as rewardTokens from liquidity mining earned by an asset manager, or BAL.

**MultiRewards**
Allows users to claim rewards proportional to staked bpt
A user may either
- `getRewards` claim these tokens to an EOA
- `getRewardsAsInternalBalance` claim these tokens to internal balance, for easy reinvestment/swaps

Credit to @TomAFrench who started this work on  `MultiRewards` on the asset-managers repo

**MerkleRedeem**
Allows users to claim rewards per the entries in a merkle tree.  It's based on: https://github.com/balancer-labs/erc20-redeemable/tree/master/merkle/contracts.  An alternative approach for rewards computed off chain would be a `permit` type scheme to facillitate custom distributions calculated off-chain by bLabs or partners

**Open questions for the future:**

*Should a `Distributor` contract hold tokens as ERC20 balance, or as internal balance?*
I think this question boils down to, do we want to prioritize cheap withdrawals to EOAs or cheap withdrawals to vault balance or EOAs:
- Holding them as internal balance would facilitate cheaper claims for LPs to internal balance - useful if you want to immediately reinvest these tokens into a pool
- Holding them as internal balance would make a claim to ERC20 balance more expensive due to vault withdrawal logic
- Holding them in internal balance increases TVL in the vault

For this PR, I implemented distributing from ERC20 balance, as I think it's simpler and cheaper for the standard use case of claiming tokens to an EOA

*Should this be used directly in the pool or into the asset manager*
Which would simplify staking/unstaking, deployment and minimize transfers required when funneling assets to these contracts

*Should we have a singleton distributor that allows you to stake bpt from multiple pools*
This would make the logic more complex but would allow LPs to claim reward tokens across pools in a single transaction

Test helper `expectBalanceChange` now accepts a `vault` arg to track internal balance changes
